### PR TITLE
Don't use docker build cache.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,14 @@ jobs:
     # variables:
     #   IMG_MATRIX_VER=${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
     steps:
+      - id: matrix-image
+        env:
+          MATRIX_VERSION: "${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}"
+          IS_LATEST: env.LATEST_IMAGE_TAG == "${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}"
+        run: |
+          echo "tag=${{ env.MATRIX_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "isLatest=${{ env.IS_LATEST }} " >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
 
       - name: Get branch names.
@@ -40,23 +48,23 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || steps.branch-names.outputs.current_branch == 'develop/actions-nocache' }}
+          push: ${{ github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}
             ALPINE_VERSION=${{ matrix.alpine_version }}
             NPM_VERSION=${{ matrix.npm_version }}
-          tags: ghcr.io/tjsr/node_patched_npm:${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
+          tags: ghcr.io/tjsr/node_patched_npm:${{ steps.matrix-image.outputs.tag }}
           outputs: |
-            type=oci,dest=/tmp/${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}.tar
-            type=registry,ref=ghcr.io/tjsr/node_patched_npm:${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
+            type=oci,dest=/tmp/${{ steps.matrix-image.outputs.tag }}.tar
+            type=registry,ref=ghcr.io/tjsr/node_patched_npm:${{ steps.matrix-image.outputs.tag }}
 
       - name: Upload OCI multi-platform image
-        if: github.ref == 'refs/heads/main' && ${{ matrix.node_version }} == ${{ env.NODE_VERSION }} && ${{ matrix.alpine_version }} == ${{ env.ALPINE_VERSION }} && ${{ matrix.npm_version }} == ${{ env.NPM_VERSION }}
+        if: github.ref == 'refs/heads/main' && ${{ steps.matrix-image.outputs.isLatest }}
         uses: actions/upload-artifact@v4
         with:
-          name: node_patched_npm_${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
-          path: /tmp/${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}.tar  
+          name: node_patched_npm_${{ steps.matrix-image.outputs.tag }}
+          path: /tmp/${{ steps.matrix-image.outputs.tag }}.tar
 
   latest:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest == 'true'
+          push: ${{ github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest == 'true' }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,11 @@ jobs:
       - id: matrix-image
         env:
           MATRIX_VERSION: "${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}"
-          IS_LATEST: env.LATEST_IMAGE_TAG == "${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}"
+
         run: |
+          IS_LATEST=$([[ "$LATEST_IMAGE_TAG" == "$MATRIX_VERSION" ]] && echo true || echo false)
           echo "tag=${{ env.MATRIX_VERSION }}" >> "$GITHUB_OUTPUT"
-          echo "isLatest=${{ env.IS_LATEST }} " >> "$GITHUB_OUTPUT"
+          echo "isLatest=$IS_LATEST" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
 
@@ -48,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest }}
+          push: github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest == 'true'
           platforms: linux/amd64,linux/arm64
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Release
 run-name: ${{ github.actor }} Building and pushing node_patched_npm
-on: [push]
+on: [push, workflow_dispatch]
 env:
   NODE_VERSION: '20.15.1'
   ALPINE_VERSION: '3.20'
@@ -51,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' && steps.artifact-exists.outputs.exists == 'false' }}
+          push: ${{ github.ref == 'refs/heads/main' && (steps.artifact-exists.outputs.exists == 'false' || github.event_name == 'workflow_dispatch') }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}
@@ -63,7 +63,7 @@ jobs:
             type=registry,ref=ghcr.io/tjsr/node_patched_npm:${{ steps.matrix-image.outputs.tag }}
 
       - name: Upload OCI multi-platform image
-        if: ${{ github.ref == 'refs/heads/main' && steps.matrix-image.outputs.isLatest == 'true' }}
+        if: ${{ github.ref == 'refs/heads/main' && (steps.matrix-image.outputs.isLatest == 'true' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@v4
         with:
           name: node_patched_npm_${{ steps.matrix-image.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,19 @@ jobs:
         alpine_version: ['3.20']
         npm_version: ['10.7.0', '10.8.2']
     runs-on: ubuntu-latest
-    # variables:
-    #   IMG_MATRIX_VER=${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
     steps:
       - id: matrix-image
         env:
           MATRIX_VERSION: "${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}"
-
         run: |
           IS_LATEST=$([[ "$LATEST_IMAGE_TAG" == "$MATRIX_VERSION" ]] && echo true || echo false)
           echo "tag=${{ env.MATRIX_VERSION }}" >> "$GITHUB_OUTPUT"
           echo "isLatest=$IS_LATEST" >> "$GITHUB_OUTPUT"
+
+      - uses: LIT-Protocol/artifact-exists-action@v0
+        id: artifact-exists
+        with:
+          name: "node_patched_npm_${{ env.LATEST_IMAGE_TAG }}"
 
       - uses: actions/checkout@v4
 
@@ -49,7 +51,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.ref == 'refs/heads/main' || steps.matrix-image.outputs.isLatest == 'true' }}
+          push: ${{ github.ref == 'refs/heads/main' && steps.artifact-exists.outputs.exists == 'false' }}
           platforms: linux/amd64,linux/arm64
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}
@@ -61,7 +63,7 @@ jobs:
             type=registry,ref=ghcr.io/tjsr/node_patched_npm:${{ steps.matrix-image.outputs.tag }}
 
       - name: Upload OCI multi-platform image
-        if: github.ref == 'refs/heads/main' && ${{ steps.matrix-image.outputs.isLatest }}
+        if: ${{ github.ref == 'refs/heads/main' && steps.matrix-image.outputs.isLatest == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: node_patched_npm_${{ steps.matrix-image.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,6 @@ jobs:
           context: .
           push: ${{ github.ref == 'refs/heads/main' || steps.branch-names.outputs.current_branch == 'develop/actions-nocache' }}
           platforms: linux/amd64,linux/arm64
-          cache-to: type=gha,mode=max
-          cache-from: type=gha
           build-args: |
             NODE_VERSION=${{ matrix.node_version }}
             ALPINE_VERSION=${{ matrix.alpine_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,14 @@ jobs:
         alpine_version: ['3.20']
         npm_version: ['10.7.0', '10.8.2']
     runs-on: ubuntu-latest
+    # variables:
+    #   IMG_MATRIX_VER=${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get branch names.
+        id: branch-names
+        uses: tj-actions/branch-names@v8
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -34,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' || steps.branch-names.outputs.current_branch == 'develop/actions-nocache' }}
           platforms: linux/amd64,linux/arm64
           cache-to: type=gha,mode=max
           cache-from: type=gha
@@ -48,7 +54,7 @@ jobs:
             type=registry,ref=ghcr.io/tjsr/node_patched_npm:${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
 
       - name: Upload OCI multi-platform image
-        if: ${{ matrix.node_version }} == ${{ env.NODE_VERSION }} && ${{ matrix.alpine_version }} == ${{ env.ALPINE_VERSION }} && ${{ matrix.npm_version }} == ${{ env.NPM_VERSION }}
+        if: github.ref == 'refs/heads/main' && ${{ matrix.node_version }} == ${{ env.NODE_VERSION }} && ${{ matrix.alpine_version }} == ${{ env.ALPINE_VERSION }} && ${{ matrix.npm_version }} == ${{ env.NPM_VERSION }}
         uses: actions/upload-artifact@v4
         with:
           name: node_patched_npm_${{ matrix.node_version }}-alpine${{ matrix.alpine_version }}-npm${{ matrix.npm_version }}
@@ -62,11 +68,6 @@ jobs:
       - name: Get branch names.
         id: branch-names
         uses: tj-actions/branch-names@v8
-
-      - name: Running on any event.
-        run: |
-          echo "Default branch: ${{ steps.branch-names.outputs.default_branch }}"
-        # Outputs: "Default branch: main"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -94,6 +95,7 @@ jobs:
 
       - name: Tag the latest image with all the variants we want
         run: |
+          BASECMD="docker tag ghcr.io/tjsr/node_patched_npm:${{ env.LATEST_IMAGE_TAG }}"
           docker tag ghcr.io/tjsr/node_patched_npm:${{ env.LATEST_IMAGE_TAG }} ghcr.io/tjsr/node_patched_npm
           docker tag ghcr.io/tjsr/node_patched_npm:${{ env.LATEST_IMAGE_TAG }} ghcr.io/tjsr/node_patched_npm:latest
           docker tag ghcr.io/tjsr/node_patched_npm:${{ env.LATEST_IMAGE_TAG }} ghcr.io/tjsr/node_patched_npm:latest-alpine${{ env.ALPINE_VERSION }}-npm${{ env.NPM_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ARG NPM_VERSION=10.8.2
 LABEL org.opencontainers.image.authors="Tim Rowe <tim@tjsr.id.au>"
 LABEL description="Node.js with most up-to-date npm versions globally installed."
 LABEL version="node$NODE_VERSION-alpine$ALPINE_VERSION-npm$NPM_VERSION"
-RUN --mount=type=cache,target=/root/.npm npm config set fund false --location=global && \
+RUN npm config set fund false --location=global && \
   npm config set update-notifier false --location=global && \
   npm install -g npm@${NPM_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION} AS node_patched_npm
 ARG NPM_VERSION=10.8.2
 LABEL org.opencontainers.image.authors="Tim Rowe <tim@tjsr.id.au>"
 LABEL description="Node.js with most up-to-date npm versions globally installed."
-LABEL version="node$NODE_VERSION-alpine$ALPINE_VERSION-npm$NPM_VERSION"
+LABEL version="node$NODE_VERSION-alpine${ALPINE_VERSION}-npm$NPM_VERSION"
 RUN npm config set fund false --location=global && \
   npm config set update-notifier false --location=global && \
   npm install -g npm@${NPM_VERSION}


### PR DESCRIPTION
Using a build cache prevents this image being used as a base image on systems that don't have that cache.